### PR TITLE
larkbot: send replies as rich post

### DIFF
--- a/cmd/larkbot/main.go
+++ b/cmd/larkbot/main.go
@@ -71,6 +71,25 @@ type downloadedResource struct {
 	messageCreate time.Time
 }
 
+type replyBody struct {
+	msgType string
+	content string
+}
+
+type postMessageContent struct {
+	ZhCN postLocale `json:"zh_cn"`
+}
+
+type postLocale struct {
+	Title   string         `json:"title,omitempty"`
+	Content [][]postMDNode `json:"content"`
+}
+
+type postMDNode struct {
+	Tag  string `json:"tag"`
+	Text string `json:"text"`
+}
+
 func (d *messageDedup) isDuplicate(messageID string) bool {
 	_, loaded := d.seen.LoadOrStore(messageID, time.Now())
 	return loaded
@@ -153,11 +172,11 @@ func main() {
 				answer = "Agent Error: " + err.Error()
 			}
 
-			content, err := buildTextContent(answer)
+			reply, err := buildReplyBody(answer)
 			if err != nil {
-				return fmt.Errorf("build reply content: %w", err)
+				return fmt.Errorf("build reply body: %w", err)
 			}
-			if err := replyMessage(ctx, apiClient, messageID, content); err != nil {
+			if err := replyMessage(ctx, apiClient, messageID, reply); err != nil {
 				return fmt.Errorf("reply message: %w", err)
 			}
 			return nil
@@ -912,25 +931,40 @@ func buildConversationKey(event *larkim.P2MessageReceiveV1) string {
 	}
 }
 
-func buildTextContent(text string) (string, error) {
-	payload := map[string]string{
-		"text": strings.TrimSpace(text),
+func buildReplyBody(text string) (replyBody, error) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		text = " "
+	}
+
+	payload := postMessageContent{
+		ZhCN: postLocale{
+			Content: [][]postMDNode{{
+				{
+					Tag:  "md",
+					Text: text,
+				},
+			}},
+		},
 	}
 	b, err := json.Marshal(payload)
 	if err != nil {
-		return "", err
+		return replyBody{}, err
 	}
-	return string(b), nil
+	return replyBody{
+		msgType: "post",
+		content: string(b),
+	}, nil
 }
 
-func replyMessage(ctx context.Context, apiClient *lark.Client, messageID, content string) error {
+func replyMessage(ctx context.Context, apiClient *lark.Client, messageID string, body replyBody) error {
 	log.Printf("[larkbot] replying to message_id=%s", messageID)
 	resp, err := apiClient.Im.V1.Message.Reply(ctx,
 		larkim.NewReplyMessageReqBuilder().
 			MessageId(messageID).
 			Body(larkim.NewReplyMessageReqBodyBuilder().
-				MsgType("text").
-				Content(content).
+				MsgType(body.msgType).
+				Content(body.content).
 				Uuid("reply-"+messageID).
 				Build()).
 			Build())

--- a/cmd/larkbot/main_test.go
+++ b/cmd/larkbot/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -68,5 +69,69 @@ func TestBuildSaveSummaryDoesNotExposeLocalPath(t *testing.T) {
 	}
 	if !strings.Contains(summary, "image_20260320_091914_om_x.png [image]") {
 		t.Fatalf("summary missing file entry: %s", summary)
+	}
+}
+
+func TestBuildReplyBodyUsesPostMarkdown(t *testing.T) {
+	answer := strings.TrimSpace("## Result\n\nSee [TiDB Docs](https://docs.pingcap.com/tidb/stable/) for details.\n\n```sql\nselect 1;\n```")
+
+	body, err := buildReplyBody(answer)
+	if err != nil {
+		t.Fatalf("buildReplyBody error: %v", err)
+	}
+	if body.msgType != "post" {
+		t.Fatalf("msgType = %q, want post", body.msgType)
+	}
+
+	var content struct {
+		ZhCN struct {
+			Content [][]struct {
+				Tag  string `json:"tag"`
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"zh_cn"`
+	}
+	if err := json.Unmarshal([]byte(body.content), &content); err != nil {
+		t.Fatalf("unmarshal content: %v", err)
+	}
+	if len(content.ZhCN.Content) != 1 || len(content.ZhCN.Content[0]) != 1 {
+		t.Fatalf("unexpected content shape: %+v", content.ZhCN.Content)
+	}
+	node := content.ZhCN.Content[0][0]
+	if node.Tag != "md" {
+		t.Fatalf("tag = %q, want md", node.Tag)
+	}
+	if node.Text != answer {
+		t.Fatalf("markdown text mismatch:\n got: %q\nwant: %q", node.Text, answer)
+	}
+	if !strings.Contains(node.Text, "[TiDB Docs](https://docs.pingcap.com/tidb/stable/)") {
+		t.Fatalf("hyperlink markdown missing: %q", node.Text)
+	}
+	if !strings.Contains(node.Text, "```sql\nselect 1;\n```") {
+		t.Fatalf("code fence markdown missing: %q", node.Text)
+	}
+}
+
+func TestBuildReplyBodyNormalizesEmptyText(t *testing.T) {
+	body, err := buildReplyBody("   \n\t ")
+	if err != nil {
+		t.Fatalf("buildReplyBody error: %v", err)
+	}
+	if body.msgType != "post" {
+		t.Fatalf("msgType = %q, want post", body.msgType)
+	}
+
+	var content struct {
+		ZhCN struct {
+			Content [][]struct {
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"zh_cn"`
+	}
+	if err := json.Unmarshal([]byte(body.content), &content); err != nil {
+		t.Fatalf("unmarshal content: %v", err)
+	}
+	if got := content.ZhCN.Content[0][0].Text; got != " " {
+		t.Fatalf("text = %q, want single space", got)
 	}
 }


### PR DESCRIPTION
## Summary
- switch larkbot reply payloads from plain text to Feishu post rich text
- send the answer through a single markdown node so markdown and link text render correctly
- add tests covering post payload generation and empty reply normalization

## Testing
- go test ./...