### PR TITLE
larkbot: add typing reaction during task execution

### DIFF
--- a/cmd/larkbot/main.go
+++ b/cmd/larkbot/main.go
@@ -29,6 +29,8 @@ const (
 	messagePageSize              = 50
 	maxUploadCommandPages        = 20
 	promptAttachmentSummaryLimit = 20
+	typingReactionType           = "Typing"
+	feishuReactionTimeout        = 10 * time.Second
 )
 
 type botIdentity struct {
@@ -147,20 +149,22 @@ func main() {
 				return nil
 			}
 
-			answer, err := handleEvent(ctx, apiClient, responder, prefetcher, attachmentManager, event)
-			if err != nil {
-				log.Printf("[larkbot] handle event error: %v (message_id=%s)", err, messageID)
-				answer = "Agent Error: " + err.Error()
-			}
+			return withTypingReaction(ctx, apiClient, messageID, func() error {
+				answer, err := handleEvent(ctx, apiClient, responder, prefetcher, attachmentManager, event)
+				if err != nil {
+					log.Printf("[larkbot] handle event error: %v (message_id=%s)", err, messageID)
+					answer = "Agent Error: " + err.Error()
+				}
 
-			content, err := buildTextContent(answer)
-			if err != nil {
-				return fmt.Errorf("build reply content: %w", err)
-			}
-			if err := replyMessage(ctx, apiClient, messageID, content); err != nil {
-				return fmt.Errorf("reply message: %w", err)
-			}
-			return nil
+				content, err := buildTextContent(answer)
+				if err != nil {
+					return fmt.Errorf("build reply content: %w", err)
+				}
+				if err := replyMessage(ctx, apiClient, messageID, content); err != nil {
+					return fmt.Errorf("reply message: %w", err)
+				}
+				return nil
+			})
 		})
 
 	cli := larkws.NewClient(cfg.FeishuAppID, cfg.FeishuAppSecret,
@@ -921,6 +925,73 @@ func buildTextContent(text string) (string, error) {
 		return "", err
 	}
 	return string(b), nil
+}
+
+func withTypingReaction(ctx context.Context, apiClient *lark.Client, messageID string, run func() error) error {
+	reactionID, err := addTypingReaction(ctx, apiClient, messageID)
+	if err != nil {
+		log.Printf("[larkbot] add typing reaction failed: %v (message_id=%s)", err, messageID)
+		return run()
+	}
+
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), feishuReactionTimeout)
+		defer cancel()
+		if err := deleteMessageReaction(cleanupCtx, apiClient, messageID, reactionID); err != nil {
+			log.Printf("[larkbot] delete typing reaction failed: %v (message_id=%s, reaction_id=%s)", err, messageID, reactionID)
+		}
+	}()
+
+	return run()
+}
+
+func addTypingReaction(ctx context.Context, apiClient *lark.Client, messageID string) (string, error) {
+	reactionCtx, cancel := context.WithTimeout(ctx, feishuReactionTimeout)
+	defer cancel()
+
+	resp, err := apiClient.Im.V1.MessageReaction.Create(reactionCtx,
+		larkim.NewCreateMessageReactionReqBuilder().
+			MessageId(messageID).
+			Body(larkim.NewCreateMessageReactionReqBodyBuilder().
+				ReactionType(larkim.NewEmojiBuilder().
+					EmojiType(typingReactionType).
+					Build()).
+				Build()).
+			Build())
+	if err != nil {
+		return "", fmt.Errorf("call create reaction API: %w", err)
+	}
+	if !resp.Success() {
+		return "", fmt.Errorf("create reaction API error: code=%d, msg=%s", resp.Code, resp.Msg)
+	}
+
+	reactionID := ""
+	if resp.Data != nil {
+		reactionID = trimPtr(resp.Data.ReactionId)
+	}
+	if reactionID == "" {
+		return "", fmt.Errorf("create reaction API returned empty reaction_id")
+	}
+
+	log.Printf("[larkbot] typing reaction added (message_id=%s, reaction_id=%s)", messageID, reactionID)
+	return reactionID, nil
+}
+
+func deleteMessageReaction(ctx context.Context, apiClient *lark.Client, messageID, reactionID string) error {
+	resp, err := apiClient.Im.V1.MessageReaction.Delete(ctx,
+		larkim.NewDeleteMessageReactionReqBuilder().
+			MessageId(messageID).
+			ReactionId(reactionID).
+			Build())
+	if err != nil {
+		return fmt.Errorf("call delete reaction API: %w", err)
+	}
+	if !resp.Success() {
+		return fmt.Errorf("delete reaction API error: code=%d, msg=%s", resp.Code, resp.Msg)
+	}
+
+	log.Printf("[larkbot] typing reaction deleted (message_id=%s, reaction_id=%s)", messageID, reactionID)
+	return nil
 }
 
 func replyMessage(ctx context.Context, apiClient *lark.Client, messageID, content string) error {

--- a/cmd/larkbot/main_test.go
+++ b/cmd/larkbot/main_test.go
@@ -1,10 +1,17 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	lark "github.com/larksuite/oapi-sdk-go/v3"
 	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
 
 	"lab/askplanner/internal/attachments"
@@ -69,4 +76,159 @@ func TestBuildSaveSummaryDoesNotExposeLocalPath(t *testing.T) {
 	if !strings.Contains(summary, "image_20260320_091914_om_x.png [image]") {
 		t.Fatalf("summary missing file entry: %s", summary)
 	}
+}
+
+func TestWithTypingReactionAddsAndDeletesReaction(t *testing.T) {
+	var (
+		createCalls int
+		deleteCalls int
+		emojiType   string
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"code":0,"msg":"success","expire":7200,"tenant_access_token":"tenant-token"}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/open-apis/im/v1/messages/om_message/reactions":
+			createCalls++
+
+			var payload struct {
+				ReactionType struct {
+					EmojiType string `json:"emoji_type"`
+				} `json:"reaction_type"`
+			}
+			if err := readJSONBody(r, &payload); err != nil {
+				t.Fatalf("read create request body: %v", err)
+			}
+			emojiType = payload.ReactionType.EmojiType
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"code":0,"msg":"success","data":{"reaction_id":"reaction-1","reaction_type":{"emoji_type":"Typing"}}}`))
+		case r.Method == http.MethodDelete && r.URL.Path == "/open-apis/im/v1/messages/om_message/reactions/reaction-1":
+			deleteCalls++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"code":0,"msg":"success","data":{"reaction_id":"reaction-1"}}`))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	apiClient := lark.NewClient("cli_a", "secret", lark.WithOpenBaseUrl(server.URL), lark.WithEnableTokenCache(false))
+
+	callbackRun := false
+	err := withTypingReaction(context.Background(), apiClient, "om_message", func() error {
+		callbackRun = true
+		if createCalls != 1 {
+			t.Fatalf("expected create before callback, got %d", createCalls)
+		}
+		if deleteCalls != 0 {
+			t.Fatalf("expected delete after callback, got %d", deleteCalls)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("withTypingReaction returned error: %v", err)
+	}
+	if !callbackRun {
+		t.Fatalf("expected callback to run")
+	}
+	if createCalls != 1 {
+		t.Fatalf("createCalls = %d, want 1", createCalls)
+	}
+	if deleteCalls != 1 {
+		t.Fatalf("deleteCalls = %d, want 1", deleteCalls)
+	}
+	if emojiType != typingReactionType {
+		t.Fatalf("emojiType = %q, want %q", emojiType, typingReactionType)
+	}
+}
+
+func TestWithTypingReactionDeletesOnCallbackError(t *testing.T) {
+	var deleteCalls int
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"code":0,"msg":"success","expire":7200,"tenant_access_token":"tenant-token"}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/open-apis/im/v1/messages/om_message/reactions":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"code":0,"msg":"success","data":{"reaction_id":"reaction-1"}}`))
+		case r.Method == http.MethodDelete && r.URL.Path == "/open-apis/im/v1/messages/om_message/reactions/reaction-1":
+			deleteCalls++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"code":0,"msg":"success","data":{"reaction_id":"reaction-1"}}`))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	apiClient := lark.NewClient("cli_b", "secret", lark.WithOpenBaseUrl(server.URL), lark.WithEnableTokenCache(false))
+
+	wantErr := errors.New("callback failed")
+	err := withTypingReaction(context.Background(), apiClient, "om_message", func() error {
+		return wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("error = %v, want %v", err, wantErr)
+	}
+	if deleteCalls != 1 {
+		t.Fatalf("deleteCalls = %d, want 1", deleteCalls)
+	}
+}
+
+func TestWithTypingReactionCreateFailureDoesNotBlockRun(t *testing.T) {
+	var (
+		createCalls int
+		deleteCalls int
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"code":0,"msg":"success","expire":7200,"tenant_access_token":"tenant-token"}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/open-apis/im/v1/messages/om_message/reactions":
+			createCalls++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"code":231001,"msg":"reaction type is invalid."}`))
+		case r.Method == http.MethodDelete:
+			deleteCalls++
+			t.Fatalf("delete should not be called when create fails")
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	apiClient := lark.NewClient("cli_c", "secret", lark.WithOpenBaseUrl(server.URL), lark.WithEnableTokenCache(false))
+
+	callbackRun := false
+	err := withTypingReaction(context.Background(), apiClient, "om_message", func() error {
+		callbackRun = true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("withTypingReaction returned error: %v", err)
+	}
+	if !callbackRun {
+		t.Fatalf("expected callback to run")
+	}
+	if createCalls != 1 {
+		t.Fatalf("createCalls = %d, want 1", createCalls)
+	}
+	if deleteCalls != 0 {
+		t.Fatalf("deleteCalls = %d, want 0", deleteCalls)
+	}
+}
+
+func readJSONBody(r *http.Request, dst any) error {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(body, dst)
 }


### PR DESCRIPTION
## Summary
- add a Typing reaction before larkbot starts processing a message
- remove the reaction with the returned reaction_id after reply handling completes
- cover success, callback error, and reaction-create failure paths with tests

## Testing
- go test ./...